### PR TITLE
Improve tweets validation

### DIFF
--- a/helpers.js
+++ b/helpers.js
@@ -68,7 +68,7 @@ export const stringify = obj => {
   if (obj && typeof obj == "object") {
     return JSON.stringify(obj);
   }
-  throw new TypeError("Input should be a string");
+  throw new TypeError("Input should be a object");
 };
 
 export const encodeToBase64 = input => Buffer.from(input).toString("base64");
@@ -96,3 +96,40 @@ export const replyTemplate = (digest, ipfsHash) => `${
 Timestamping status: https://timestamp.decred.org/results?digests=${digest}&timestamp=false \n \n
 Thread json: https://ipfs.io/ipfs/${ipfsHash}
 `;
+
+export const cleanTweetText = text => {
+  if (!text || typeof text !== "string") {
+    throw new TypeError("Input must be a valid string");
+  }
+  const undesiredTags = /^(@[a-zA-z_0-9]+[ ])*/.exec(text)[0];
+  const cleanedText = undesiredTags ? text.replace(undesiredTags, "") : text;
+
+  return cleanedText;
+};
+
+export const isRetweet = tweet => {
+  const isRetweet = !!tweet.retweeted_status;
+  return isRetweet;
+};
+
+export const isReplyToBotTweet = (tweet, tag) => {
+  const { in_reply_to_screen_name, in_reply_to_status_id_str } = tweet;
+  const isReplyToBot =
+    in_reply_to_status_id_str && in_reply_to_screen_name === tag;
+  return isReplyToBot;
+};
+
+export const validateTweet = (tweet, tag) => {
+  if (!tweet || !tweet.text || typeof tweet.text !== "string") {
+    throw new TypeError("Invalid tweet input");
+  }
+
+  if (isReplyToBotTweet(tweet, tag) || isRetweet(tweet)) {
+    return false;
+  }
+
+  const { text } = tweet;
+  const cleanedText = cleanTweetText(text);
+  const botIsMentioned = cleanedText.toLowerCase().includes(tag);
+  return botIsMentioned;
+};

--- a/index.js
+++ b/index.js
@@ -117,12 +117,6 @@ const dealWithTweet = ({ userId, tweetId }) => {
   }
 };
 
-const validateBotTag = ({ text }) => {
-  const regex = /^(@[a-zA-z1..0]+[ ])*/;
-  const result = regex.exec(text);
-  logger.debug(result);
-};
-
 const startStreaming = () => {
   const stream = T.stream("statuses/filter", {
     track: process.env.TRACKED_WORD,

--- a/test/helpers.test.js
+++ b/test/helpers.test.js
@@ -120,6 +120,18 @@ describe("validateTweet", async assert => {
     expected: true
   });
   assert({
+    given: "a text containing the mention preceded by a blank space",
+    should: "return true",
+    actual: Try(validateTweet, { text: " @tag" }, "@tag"),
+    expected: true
+  });
+  assert({
+    given: "a text containing the mention followed by a blank space",
+    should: "return false",
+    actual: Try(validateTweet, { text: "@tag " }, "@tag"),
+    expected: false
+  });
+  assert({
     given: "invalid input",
     should: "throw",
     actual: Try(validateTweet, null),

--- a/test/helpers.test.js
+++ b/test/helpers.test.js
@@ -1,5 +1,11 @@
 import { describe, Try } from "riteway";
-import { stringify, encodeToBase64, normalizeDataToDcrtime } from "../helpers";
+import {
+  stringify,
+  encodeToBase64,
+  normalizeDataToDcrtime,
+  cleanTweetText,
+  validateTweet
+} from "../helpers";
 
 describe("stringify", async assert => {
   assert({
@@ -18,7 +24,7 @@ describe("stringify", async assert => {
     given: "obj",
     should: "return stringified obj",
     actual: stringify({ test: 1 }),
-    expected: "{\"test\":1}"
+    expected: '{"test":1}'
   });
 });
 describe("encodeToBase64", async assert => {
@@ -48,7 +54,7 @@ describe("encodeToBase64", async assert => {
   });
 });
 
-describe("normalizeDataToDcrtime", async (assert) => {
+describe("normalizeDataToDcrtime", async assert => {
   assert({
     given: "no arguments or undefined",
     should: "throw",
@@ -66,5 +72,57 @@ describe("normalizeDataToDcrtime", async (assert) => {
     should: "return array with 1 object containing a payload key",
     actual: Try(normalizeDataToDcrtime, "dGVzdA=="),
     expected: ["dGVzdA=="]
+  });
+});
+
+describe("cleanTweetText", async assert => {
+  assert({
+    given: "a text with tags in the beggining",
+    should: "return the text without the tags",
+    actual: Try(cleanTweetText, "@tag1 @tag2 text body"),
+    expected: "text body"
+  });
+  assert({
+    given: "a text with tags in the beggining and in the middle",
+    should: "remove the tags from the beggning and keep the middle ones",
+    actual: Try(cleanTweetText, "@tag1 @tag2 text body @midtag more text"),
+    expected: "text body @midtag more text"
+  });
+  assert({
+    given: "invalid input",
+    should: "throw",
+    actual: Try(cleanTweetText, null),
+    expected: new TypeError()
+  });
+});
+
+describe("validateTweet", async assert => {
+  assert({
+    given: "a invalid tweet text",
+    should: "return false",
+    actual: Try(validateTweet, { text: "@tag text body" }, "@tag"),
+    expected: false
+  });
+  assert({
+    given: "a valid tweet text",
+    should: "return true",
+    actual: Try(
+      validateTweet,
+      { text: "@tag text body @tag more text" },
+      "@tag"
+    ),
+    expected: true
+  });
+  assert({
+    given: "a text containing only the mention",
+    should: "return true",
+    actual: Try(validateTweet, { text: "@tag" }, "@tag"),
+    expected: true
+  });
+  assert({
+    given: "invalid input",
+    should: "throw",
+    actual: Try(validateTweet, null),
+    expected: new TypeError()
   });
 });


### PR DESCRIPTION
This PR adds more validation to the tweets captured by the stream. 
The tweets containing the bot mention at the beginning of the text followed by a blank space  (e.g "@dcrtimestampbot ") will not be processed by the bot.
