### PR TITLE
Throw errors up the async pipe and log it in the upperstream

### DIFF
--- a/index.js
+++ b/index.js
@@ -52,8 +52,9 @@ const processTweetThread = async ({ tweetId, userId }) => {
       userId
     };
   } catch (e) {
-    logger.error(`processTweetThreadError ${tweetId}: ${e}`);
-    return e;
+    throw new Error(
+      `processTweetThread error tweetID: ${tweetId}, error: ${e}`
+    );
   }
 };
 
@@ -70,8 +71,7 @@ const replyResults = async ({ userId, tweetId, threadDigest, ipfsHash }) => {
       userId
     };
   } catch (e) {
-    logger.error(e);
-    return e;
+    throw new Error(`replyResults error tweetID: ${tweetId} `);
   }
 };
 
@@ -81,8 +81,7 @@ const dmResult = async ({ userId, status }) => {
     await T.post("direct_messages/events/new", params);
     logger.info(`DM sent to user: ${userId}`);
   } catch (e) {
-    logger.error(e);
-    return e;
+    throw new Error(`dmResult error userId: ${userId} `);
   }
 };
 
@@ -106,14 +105,14 @@ ipfs.on("ready", async () => {
 });
 
 const dealWithTweet = ({ userId, tweetId }) => {
-  logger.info(`dealing with tweet ${tweetId}`);
+  logger.info(`dealing with tweet ${tweetId} from user ${userId}`);
   try {
     return asyncPipe(processTweetThread, replyResults, dmResult)({
       userId,
       tweetId
     });
   } catch (e) {
-    return e;
+    throw e;
   }
 };
 
@@ -127,7 +126,6 @@ const startStreaming = () => {
     if (!validateTweet(tweet, process.env.TRACKED_WORD)) {
       return;
     }
-
     try {
       await dealWithTweet({ userId: tweet.user.id_str, tweetId: tweet.id_str });
     } catch (e) {

--- a/index.js
+++ b/index.js
@@ -104,15 +104,15 @@ ipfs.on("ready", async () => {
   // dealWithTweet("1116024316339130369");
 });
 
-const dealWithTweet = ({ userId, tweetId }) => {
+const dealWithTweet = async ({ userId, tweetId }) => {
   logger.info(`dealing with tweet ${tweetId} from user ${userId}`);
   try {
-    return asyncPipe(processTweetThread, replyResults, dmResult)({
+    await asyncPipe(processTweetThread, replyResults, dmResult)({
       userId,
       tweetId
     });
   } catch (e) {
-    throw e;
+    logger.error("dealWithTweet error:", e);
   }
 };
 
@@ -122,15 +122,11 @@ const startStreaming = () => {
     retry: true
   });
   logger.info("Waiting for tweets to show up...");
-  stream.on("tweet", async tweet => {
+  stream.on("tweet", tweet => {
     if (!validateTweet(tweet, process.env.TRACKED_WORD)) {
       return;
     }
-    try {
-      await dealWithTweet({ userId: tweet.user.id_str, tweetId: tweet.id_str });
-    } catch (e) {
-      logger.error("dealWithTweet error:", e);
-    }
+    dealWithTweet({ userId: tweet.user.id_str, tweetId: tweet.id_str });
   });
 
   stream.on("error", e => {

--- a/index.js
+++ b/index.js
@@ -131,7 +131,11 @@ const startStreaming = () => {
     if (!validateTweet(tweet, process.env.TRACKED_WORD)) {
       return;
     }
-    dealWithTweet({ userId: tweet.user.id_str, tweetId: tweet.id_str });
+    dealWithTweet({ userId: tweet.user.id_str, tweetId: tweet.id_str }).catch(
+      e => {
+        logger.error(e);
+      }
+    );
   });
 
   stream.on("error", e => {


### PR DESCRIPTION
This PR deals with the fact the bot was crashing when a step of the pipe crashed. This was happening because of the pipe steps returning the error instead of throwing, causing the pipe to continue its execution.
closes https://github.com/tiagoalvesdulce/dcrtimestamptweet/issues/13